### PR TITLE
Fix same-column drag & drop and icon path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-kanban",
-  "version": "1.1.2",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-kanban",
-      "version": "1.1.2",
+      "version": "1.3.1",
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "18.x",
@@ -740,6 +740,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -945,6 +946,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1840,6 +1842,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5278,6 +5281,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "看板",
     "任务管理"
   ],
-  "icon": "./imgs/logo.png",
+  "icon": "imgs/logo.png",
   "activationEvents": [
     "onLanguage:markdown"
   ],

--- a/src/html/webviewScript.js
+++ b/src/html/webviewScript.js
@@ -460,7 +460,7 @@ function setupTaskDragAndDrop() {
       const fromColumnId = e.dataTransfer.getData('application/column-id')
 
       if (taskId && fromColumnId) {
-        const dropIndex = calculateDropIndex(tasksContainer, e.clientY, fromColumnId, columnId)
+        const dropIndex = calculateDropIndex(tasksContainer, e.clientY, fromColumnId, columnId, taskId)
         
         vscode.postMessage({
           type: 'moveTask',
@@ -478,7 +478,7 @@ function setupTaskDragAndDrop() {
   })
 }
 
-function calculateDropIndex(tasksContainer, clientY, fromColumnId, toColumnId) {
+function calculateDropIndex(tasksContainer, clientY, fromColumnId, toColumnId, draggedTaskId) {
   const tasks = Array.from(tasksContainer.children)
   let dropIndex = tasks.length
 
@@ -494,7 +494,7 @@ function calculateDropIndex(tasksContainer, clientY, fromColumnId, toColumnId) {
   }
 
   if (fromColumnId === toColumnId) {
-    const draggedTaskElement = tasksContainer.querySelector('[data-task-id="' + e.dataTransfer.getData('text/plain') + '"]')
+    const draggedTaskElement = tasksContainer.querySelector('[data-task-id="' + draggedTaskId + '"]')
     if (draggedTaskElement) {
       const currentIndex = Array.from(tasks).indexOf(draggedTaskElement)
       if (dropIndex > currentIndex) {


### PR DESCRIPTION
I’m a vibe‑coder and ran into a drag‑and‑drop issue: tasks could move between columns, but not within the same column. This PR fixes the root cause and also cleans up the icon path so VSIX packaging works reliably.

### What changed
- Fix same‑column drag & drop by passing `taskId` into `calculateDropIndex` and avoiding an undefined `e`.
- Normalize extension icon path in `package.json` so `vsce package` finds it.

### Why

- Same‑column reordering was broken because `calculateDropIndex` referenced `e.dataTransfer` even though `e` is out of scope.
- The icon path `./imgs/logo.png` caused packaging errors in some environments.

### How to test

1. Open a markdown kanban file with 1 column and 3 tasks.
2. Drag Task A below Task B **within the same column**.
3. Confirm the order updates correctly.
4. Run `npx vsce package` to ensure packaging succeeds.

### Notes

- The fix is minimal and keeps existing drag behavior intact for cross‑column moves.
